### PR TITLE
Fixed command names in supervisor config files (apiaxle_ should be apiaxle-)

### DIFF
--- a/thirdparty-conf/supervisord/apiaxle-api.conf
+++ b/thirdparty-conf/supervisord/apiaxle-api.conf
@@ -1,6 +1,6 @@
 [program:apiaxle-api]
 process_name = apiaxle-api-%(process_num)s
-command = apiaxle_api -f 1 -p %(process_num)s
+command = apiaxle-api -f 1 -p %(process_num)s
 directory = /home/apiaxle/apiaxle/api
 numprocs = 4
 numprocs_start = 3000

--- a/thirdparty-conf/supervisord/apiaxle-proxy.conf
+++ b/thirdparty-conf/supervisord/apiaxle-proxy.conf
@@ -1,6 +1,6 @@
 [program:apiaxle-proxy]
 process_name = apiaxle-proxy-%(process_num)s
-command = apiaxle_proxy -f 1 -p %(process_num)s
+command = apiaxle-proxy -f 1 -p %(process_num)s
 directory = /home/apiaxle/apiaxle/proxy
 numprocs = 4
 numprocs_start = 2000


### PR DESCRIPTION
For some reason apiaxle commands in `apiaxle-api.conf` and `apiaxle-proxy.conf` had the command to fire off the processes listed with the `apiaxle_` prefix when it should be `apiaxle-` 
