### PR TITLE
Respond w/ xml on errors when accept header set to application/xml

### DIFF
--- a/base/lib/application.coffee
+++ b/base/lib/application.coffee
@@ -171,6 +171,9 @@ class exports.AxleApp extends Application
       if query and query.format and query.format in [ "xml", "json" ]
         return query.format
 
+    if /application\/xml/.test(req.headers.accept)
+      return "xml"
+
     if req.api?.data.apiFormat is "xml"
       return "xml"
 


### PR DESCRIPTION
I thought it would be nice if the proxy would respond with xml (for error responses) when the client has set the request accept header to "application/xml"

We are using apiaxle as a gateway for our api which accepts and provides payloads in either json or xml format based on the requester's accept and content-type headers.  With this modification, our clients will also receive any key/throttling related errors in their desired accept content-type.
