### PR TITLE
Support for Authenticated Redis Instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ npm-debug.log
 /proxy/coverage
 *.log
 *#
+.idea

--- a/base/lib/application.coffee
+++ b/base/lib/application.coffee
@@ -64,7 +64,6 @@ class exports.AxleApp extends Application
   redisConnect: ( client_name, cb ) =>
     # grab the redis config
     { port, host, sentinel, auth } = @config.redis
-    console.log({ port, host, sentinel, auth });
     # are we up for some sentinel fun?
     this[client_name] = null
     if sentinel

--- a/base/lib/application.coffee
+++ b/base/lib/application.coffee
@@ -63,8 +63,8 @@ class exports.AxleApp extends Application
 
   redisConnect: ( client_name, cb ) =>
     # grab the redis config
-    { port, host, sentinel } = @config.redis
-
+    { port, host, sentinel, auth } = @config.redis
+    console.log({ port, host, sentinel, auth });
     # are we up for some sentinel fun?
     this[client_name] = null
     if sentinel
@@ -77,7 +77,7 @@ class exports.AxleApp extends Application
       this[client_name].on "failover-end", => @logger.warn "Failover ends."
       this[client_name].on "disconnected", => @logger.warn "Old master disconnected."
     else
-      this[client_name] = Redis.createClient port, host
+      this[client_name] = Redis.createClient port, host, { auth_pass: auth}
 
     this[client_name].on "error", ( err ) => @logger.warn "#{ err }"
     this[client_name].on "ready", cb
@@ -140,6 +140,9 @@ class exports.AxleApp extends Application
             host:
               type: "string"
               default: "localhost"
+            auth:
+              type: "string"
+              default: ""
 
   getRoutingSchema: ->
     {}=


### PR DESCRIPTION
I added an additional config option for "auth" which gets passed to the redis client.  In reading the docs and in my sandbox, the redis client will store the auth and on reconnects etc use your auth.  I have tested locally that I can connect to a password protected redis instance and then shut down the redis instance and restarted it to make sure the reconnect worked using the auth.