### PR TITLE
fix duplicate CORS headers, use upstream CORS headers where available

### DIFF
--- a/proxy/apiaxle-proxy.coffee
+++ b/proxy/apiaxle-proxy.coffee
@@ -374,11 +374,20 @@ class exports.ApiaxleProxy extends AxleApp
   applyCors: ( req, res, next ) =>
     # If CORS is not enabled, proceed
     if req.api.data.corsEnabled
-      res.setHeader "Access-Control-Allow-Origin", "*"
-      res.setHeader "Access-Control-Allow-Credentials", "true"
-      res.setHeader "Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD"
-      res.setHeader "Access-Control-Allow-Headers", "Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token"
-      res.setHeader "Access-Control-Expose-Headers", "content-type, content-length, X-ApiaxleProxy-Qps-Left, X-ApiaxleProxy-Qpd-Left"
+      if not req.headers["access-control-allow-origin"]
+        res.setHeader "access-control-allow-origin", "*"
+
+      if not req.headers["access-control-allow-credentials"]
+        res.setHeader "access-control-allow-credentials", "true"
+
+      if not req.headers["access-control-allow-methods"]
+        res.setHeader "access-control-allow-methods", "GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD"
+
+      if not req.headers["access-control-allow-headers"]
+        res.setHeader "access-control-allow-headers", "Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token"
+
+      if not req.headers["access-control-expose-headers"]
+        res.setHeader "access-control-expose-headers", "content-type, content-length, X-ApiaxleProxy-Qps-Left, X-ApiaxleProxy-Qpd-Left"
 
     return next()
 


### PR DESCRIPTION
it turns out apiaxle sets duplicate headers for CORS requests when also specified upstream, eg.
```bash
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD
< Access-Control-Allow-Headers: Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token
< Access-Control-Expose-Headers: content-type, content-length, X-ApiaxleProxy-Qps-Left, X-ApiaxleProxy-Qpd-Left
< X-ApiaxleProxy-Qps-Left: 0
< X-ApiaxleProxy-Qpd-Left: 27790
< access-control-allow-credentials: true
< access-control-allow-headers: X-Requested-With,content-type
< access-control-allow-methods: GET, OPTIONS
< access-control-allow-origin: *
```

this is actually a symptom of a bigger issue, `http.js` [lowercases response headers](https://github.com/nodejs/node/blob/master/lib/_http_outgoing.js#L336) (exposed in `req.headers`), which is super-useful so you don't have to do case checking all the time for things [such as this](https://github.com/apiaxle/apiaxle/blob/413bf526daa8fc0741c763a0a40b56726a09f190/proxy/apiaxle-proxy.coffee#L116) but it means that the original case of the upstream headers is lost in the process.

there has been a discussion about this [over in node land](https://github.com/nodejs/node-v0.x-archive/issues/1954), the tl;dr of which is that while maintaining case of the upstream headers would be cool, the spec says that they are [case insensitive](https://github.com/nodejs/node-v0.x-archive/issues/1954#issuecomment-2547360), and I tend to agree with [Felix](https://github.com/nodejs/node-v0.x-archive/issues/1954#issuecomment-2552895) that regardless of upper/lower no 'real' information is lost in the transformation.

the problem is that `expressjs` has then decided that `req.setHeader()` will set the header in the case you specified rather than *also* lowercasing it to be consistent.

for most apps this isn't really an issue, but for a proxy it means that things like the above happen.

luckily this only seems to affect CORS at this time as there seem to be no other headers which can cause similar keys collisions (from a cursory grep).

my PR simply lowercases the CORS keys and also has a change to the behaviour of `applyCors()` in that it **only sets CORS headers which are not explicitly set upstream** otherwise you run the risk of clobbering the CORS headers set by the upstream app, in the example above I might; for example; want a different value for `access-control-allow-methods`.

I had some trouble trying to run tests for the proxy code, maybe you could point me to an install reference for that and I'll add a test case.

thoughts?



