### PR TITLE
update dependencies for node 0.12 and node 4

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "lodash": "~1.2.0",
     "apiaxle-base": "1.12.35",
-    "libxmljs": "~0.7.1",
+    "libxmljs": "0.14.x",
     "moment": "~2.0.0",
     "scarf": "0.0.10",
     "sinon": "~1.6.0",

--- a/base/package.json
+++ b/base/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "lodash": "~1.2.0",
-    "js2xml": "apiaxle/js2xml#v1.0.3",
+    "js2xml": "^1.0.4",
     "libxmljs": "0.14.x",
     "date-utils": "~1.2.13",
     "scarf": "0.0.10",
@@ -25,7 +25,7 @@
     "express": "~3.2.6",
     "async": "~0.2.9",
     "redis": "^0.10.3",
-    "hiredis": "^0.1.17"
+    "hiredis": "^0.4.1"
   },
   "devDependencies": {
     "twerp": "~1.0.7",


### PR DESCRIPTION
update dependencies for node 0.12.x and node 4.x.x
- js2xml updated their dependencies so we no longer have to point to a fork.
- update hiredis version for node 4 compatibility (still works with 0.10 and 0.12)
- update libxmljs version in apiaxle-api for node 0.12+ compatibilty

closes #81