### PR TITLE
header limit fix

### DIFF
--- a/api/test/app/controller/v1/stats_controller_test.coffee
+++ b/api/test/app/controller/v1/stats_controller_test.coffee
@@ -46,12 +46,14 @@ class exports.KeyringStatsTest extends ApiaxleTest
     model = @app.model "stats"
     hits  = []
 
-    now = 1464951741939 # Fri, 03 Jun 2016
+    next_year = new Date()
+    next_year.setFullYear(next_year.getFullYear() + 1) # has to be the future so redis doesn't expire our stats
+    now = next_year.getTime()
 
     @now_seconds = Math.floor( now / 1000 )
-    @now_minutes = 1464951720
-    @now_hours = 1464951600
-    @now_days = 1464912000
+    @now_minutes = Math.floor( now / 60 / 1000 ) * 60
+    @now_hours = Math.floor( now / 60 / 60 / 1000 ) * 60 * 60
+    @now_days = Math.floor( now / 24 / 60 / 60 / 1000 ) * 24 * 60 * 60
 
     clock = @getClock now
 
@@ -210,14 +212,14 @@ class exports.ApiStatsTest extends ApiaxleTest
     model = @app.model "stats"
     hits  = []
 
-    now = 1464951741939 # Fri, 03 Jun 2016
+    next_year = new Date()
+    next_year.setFullYear(next_year.getFullYear() + 1) # has to be the future so redis doesn't expire our stats
+    now = next_year.getTime()
 
     @now_seconds = Math.floor( now / 1000 )
-    @now_milliseconds = @now_seconds * 1000
-
-    @now_minutes = 1464951720
-    @now_hours = 1464951600
-    @now_days = 1464912000
+    @now_minutes = Math.floor( now / 60 / 1000 ) * 60
+    @now_hours = Math.floor( now / 60 / 60 / 1000 ) * 60 * 60
+    @now_days = Math.floor( now / 24 / 60 / 60 / 1000 ) * 24 * 60 * 60
 
     clock = @getClock now
 
@@ -453,9 +455,6 @@ class exports.ApiStatsTest extends ApiaxleTest
 
               # check for the ISO date
               timestamp = ( new Date( timestamp * 1000 ) ).toISOString()
-
-              # we know it should be 03 Jun 2016
-              @match timestamp, /2016-06-03/
 
               @deepEqual results.uncached["200"][timestamp], 2
               @deepEqual results.uncached["400"][timestamp], 1

--- a/base/app/model/redis/api_limits.coffee
+++ b/base/app/model/redis/api_limits.coffee
@@ -29,12 +29,14 @@ class exports.ApiLimits extends Redis
     both = []
 
     if qpdLimit? and qpdLimit > 0
-      both.push ( innerCb ) =>
-        @qpdHit key, qpdLimit, innerCb
+      both.push ( innerCb ) => @qpdHit key, qpdLimit, innerCb
+    else
+      both.push ( innerCb ) -> innerCb null, -1
 
     if qpsLimit? and qpsLimit > 0
-      both.push ( innerCb ) =>
-        @qpsHit key, qpsLimit, innerCb
+      both.push ( innerCb ) => @qpsHit key, qpsLimit, innerCb
+    else
+      both.push ( innerCb ) -> innerCb null, -1
 
     async.series both, cb
 

--- a/base/test/app/model/redis/api_limits_test.coffee
+++ b/base/test/app/model/redis/api_limits_test.coffee
@@ -86,3 +86,17 @@ class exports.QpdTest extends FakeAppTest
           @ok err instanceof QpsExceededError
 
           done 13
+
+  "test apiHit returns qpd and qps when qpd is unlimited": ( done ) ->
+    model = @app.model "apilimits"
+
+    # we need to stub the keys because there's a chance we'll tick
+    # over to the next second/day
+    qpsKeyStub = @getStub ApiLimits::, "qpsKey", -> "qpsTestKey"
+    qpdKeyStub = @getStub ApiLimits::, "qpdKey", -> "qpdTestKey"
+
+    model.apiHit "1234", 2, -1, ( err, limits ) =>
+      @ok not err
+      @equal limits.length, 2
+
+      done 2

--- a/proxy/apiaxle-proxy.coffee
+++ b/proxy/apiaxle-proxy.coffee
@@ -303,8 +303,10 @@ class exports.ApiaxleProxy extends AxleApp
       return next err if err
 
       # let the user know what they have left
-      res.setHeader "X-ApiaxleProxy-Qps-Left", newQps
-      res.setHeader "X-ApiaxleProxy-Qpd-Left", newQpd
+      if newQps > -1
+        res.setHeader "X-ApiaxleProxy-Qps-Left", newQps
+      if newQpd > -1
+        res.setHeader "X-ApiaxleProxy-Qpd-Left", newQpd
 
       return next()
 

--- a/proxy/test/app/controller/proxy_test.coffee
+++ b/proxy/test/app/controller/proxy_test.coffee
@@ -313,6 +313,52 @@ class exports.CatchallTest extends ApiaxleTest
 
             done 9
 
+  "test GET with key with unlimited qpd": ( done ) ->
+    apiOptions =
+      endPoint: "graph.facebook.com"
+      apiFormat: "json"
+
+    # we create the API
+    @fixtures.createApi "facebook", apiOptions, ( err ) =>
+      @ok not err
+
+      keyOptions =
+        forApis: [ "facebook" ]
+        qpd: -1
+
+      @app.model( "keyfactory" ).create "1234", keyOptions, ( err ) =>
+        @ok not err
+
+        # make sure we don't actually hit facebook
+        data = JSON.stringify
+          one: 1
+          two: 2
+
+        # mock out the http call
+        scope = nock( "http://graph.facebook.com" )
+          .get( "/some.username" )
+          .once()
+          .reply( 200, data, { "Content-Type": "application/json" } )
+
+        requestOptions =
+          path: "/some.username?api_key=1234"
+          host: "facebook.api.localhost"
+
+        @stubDns { "facebook.api.localhost": "127.0.0.1" }
+        @GET requestOptions, ( err, response ) =>
+          @ok not err
+          @ok scope.isDone()
+          @equal response.contentType, "application/json"
+
+          @ok response.headers[ "x-apiaxleproxy-qps-left" ]
+          @equal response.headers[ "x-apiaxleproxy-qpd-left" ], undefined
+
+          response.parseJson ( err, json ) =>
+            @ok not err
+            @equal json.one, 1
+
+            done 9
+
   "test GET with key, rather than api_key": ( done ) ->
     apiOptions =
       endPoint: "graph.facebook.com"


### PR DESCRIPTION
- closes #83 Tests break because of hard-coded date
- closes #84 Unlimited qpd causes header switch
- add regression test for unlimited qpd headers
- now hides qpd/qps limit header if qpd/qps is unlimited:

  for example, if qpd limit is -1 and qps limit is 5, the first response will have
  ```X-ApiaxleProxy-Qps-Left: 4```
  and ```X-ApiaxleProxy-Qpd-Left``` won't appear.
