### PR TITLE
fix tests for docker

### DIFF
--- a/base/lib/mixins/http-helpers.coffee
+++ b/base/lib/mixins/http-helpers.coffee
@@ -86,7 +86,7 @@ exports.httpHelpers =
     req.on "error", ( err ) -> cb err, null
 
     # write the body if we're meant to
-    if options.data and options.method not in [ "HEAD", "GET" ]
+    if options.data and options.method not in [ "HEAD", "GET", "DELETE" ]
       req.write options.data
 
     req.end()

--- a/base/lib/test.coffee
+++ b/base/lib/test.coffee
@@ -97,7 +97,9 @@ class exports.AppTest extends TwerpTest
     # exist on everyone's machine
     old = dns.lookup
 
-    @getStub dns, "lookup", ( domain, cb ) ->
+    @getStub dns, "lookup", ( domain, options, cb ) ->
+      if typeof options == 'function'
+        cb = options
       for name, address of mapping
         if domain is name
           return cb null, address, 4


### PR DESCRIPTION
Update stubDns to account for [dns.lookup](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback)'s optional 2nd parameter.
Don't pass body with DELETE http requests because it fails when running in docker.

Note: tests will fail until #85 is merged because `develop` is currently failing tests.