### PR TITLE
only share sub-dirs in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     ports:
       - 3100:3100
     volumes:
-      - ./:/app/apiaxle
+      - ./api:/app/apiaxle/api
+      - ./base:/app/apiaxle/base
     depends_on:
       - redis
     environment:
@@ -23,7 +24,8 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - ./:/app/apiaxle
+      - ./proxy:/app/apiaxle/proxy
+      - ./base:/app/apiaxle/base
     depends_on:
       - redis
     environment:
@@ -37,7 +39,10 @@ services:
       context: .
       dockerfile: Dockerfile-development
     volumes:
-      - ./:/app/apiaxle
+      - ./repl:/app/apiaxle/repl
+      - ./api:/app/apiaxle/api
+      - ./proxy:/app/apiaxle/proxy
+      - ./base:/app/apiaxle/base
     depends_on:
       - redis
     environment:


### PR DESCRIPTION
docker-compose.yml is broken because node_modules moved from /app to /app/apiaxle, so volume sharing the entire apiaxle folder is overwriting node_modules.

this switches it to only volume share the sub-directories api, base, proxy, and repl.