### PR TITLE
add docs generation to docker-compose

### DIFF
--- a/api/bin/generate-docs.coffee
+++ b/api/bin/generate-docs.coffee
@@ -134,7 +134,7 @@ genExample = ( controller ) ->
 outputExample = ( controller ) ->
   print "<p><pre>#{ genExample controller }</pre></p>"
 
-exec "git rev-parse --abbrev-ref HEAD", ( err, stdout ) ->
+exec "GIT_DISCOVERY_ACROSS_FILESYSTEM=1 git rev-parse --abbrev-ref HEAD", ( err, stdout ) ->
   console.error( err ) if err
 
   branch = stdout.replace /\n/g, ""

--- a/api/config/docs.json
+++ b/api/config/docs.json
@@ -1,6 +1,6 @@
 {
   "redis": {
-    "host": "localhost",
+    "host": "redis",
     "port": 6379
   },
   "application": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     ports:
       - 3100:3100
     volumes:
-      - ./:/app/apiaxle
+      - ./api:/app/apiaxle/api
+      - ./base:/app/apiaxle/base
     depends_on:
       - redis
     environment:
@@ -23,7 +24,8 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - ./:/app/apiaxle
+      - ./proxy:/app/apiaxle/proxy
+      - ./base:/app/apiaxle/base
     depends_on:
       - redis
     environment:
@@ -37,7 +39,11 @@ services:
       context: .
       dockerfile: Dockerfile-development
     volumes:
-      - ./:/app/apiaxle
+      - ./repl:/app/apiaxle/repl
+      - ./api:/app/apiaxle/api
+      - ./proxy:/app/apiaxle/proxy
+      - ./base:/app/apiaxle/base
+      - ./.git:/app/apiaxle/.git
     depends_on:
       - redis
     environment:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -51,6 +51,12 @@ elif [ $app = 'test' ]; then
   make
   make test
 
+elif [ $app = 'docs' ]; then
+  cd /app/apiaxle
+  make > /dev/null
+  cd /app/apiaxle/api
+  bin/generate-docs.coffee
+
 else
   if [ $NODE_ENV != 'production' ]; then
     # When NODE_ENV isn't 'production', run as coffee for watch and recompile


### PR DESCRIPTION
- add `docker-compose run repl docs` for apiaxle/website to call to update the api docs
- fix volume sharing from overwriting node_modules by only sharing sub directories
- share .git directory in the repl container so the docs generation script can get the current branch

current steps to generate docs:
- git clone apiaxle/apiaxle and apiaxle/website so they live side by side
- in the apiaxle directory run `docker-compose build`
- in the website directory run `bin/generate-api-docs.bash`